### PR TITLE
Remove replicaset from deafult resources and add postdeploy hook to presubmit

### DIFF
--- a/postdeploy-hooks/k8s-cleanup/main.go
+++ b/postdeploy-hooks/k8s-cleanup/main.go
@@ -15,7 +15,7 @@ var (
 		"For multiple namespaces, separate them with a comma. For example --namespace=foo,bar. By default "+
 		"resources will be deleted across all namespaces.")
 	resourceType = flag.String("resource-type",
-		"service,cronjob.batch,job.batch,deployment.apps,replicaset.apps,statefulset.apps,pod,configmap,secret,horizontalpodautoscaler.autoscaling",
+		"service,cronjob.batch,job.batch,deployment.apps,statefulset.apps,pod,configmap,secret,horizontalpodautoscaler.autoscaling",
 		"Comma separated list of resource type(s) to filter on when finding "+
 			"resources to delete. See default list above of resources that will"+
 			"be deleted. To have ALL resources deleted pass in \"all\". "+

--- a/postdeploy-hooks/k8s-cleanup/quickstart/QUICKSTART.md
+++ b/postdeploy-hooks/k8s-cleanup/quickstart/QUICKSTART.md
@@ -9,7 +9,6 @@ a command line flag:
 * cronjob.batch
 * job.batch
 * deployment.apps
-* replicaset.apps
 * statefulset.apps
 * pod
 * configmap

--- a/postdeploy-hooks/k8s-cleanup/quickstart/config-samples/skaffold.yaml
+++ b/postdeploy-hooks/k8s-cleanup/quickstart/config-samples/skaffold.yaml
@@ -21,4 +21,4 @@ customActions:
     # delete all resources, pass in "all" as the resource-type.
     args:
     # - --namespace=foo,bar
-    # - --resource-type=service,cronjob.batch,job.batch,deployment.apps,replicaset.apps,statefulset.apps,pod,configmap,secret,horizontalpodautoscaler.autoscaling
+    # - --resource-type=service,cronjob.batch,job.batch,deployment.apps,statefulset.apps,pod,configmap,secret,horizontalpodautoscaler.autoscaling

--- a/presubmit.yaml
+++ b/presubmit.yaml
@@ -9,6 +9,7 @@ steps:
       go build -C custom-targets/terraform/terraform-deployer
       go build -C custom-targets/infrastructure-manager/im-deployer
       go build -C custom-targets/vertex-ai/model-deployer
+      go build -C postdeploy-hooks/k8s-cleanup
       go build -C colors-e2e/colors-be
       go build -C colors-e2e/colors-fd
   - name: docker
@@ -18,3 +19,4 @@ steps:
         docker build custom-targets/terraform/terraform-deployer
         docker build custom-targets/infrastructure-manager/im-deployer
         docker build custom-targets/vertex-ai/model-deployer
+        docker build postdeploy-hooks/k8s-cleanup


### PR DESCRIPTION
- Remove ReplicaSet from the default list of resources to delete
- Add the postdeploy-hook sample to the presubmit check