### PR TITLE
chore: simplify presubmit

### DIFF
--- a/presubmit.yaml
+++ b/presubmit.yaml
@@ -1,22 +1,10 @@
 # Cloud Build YAML to run all presubmit tasks
 steps:
-  - name: golang
-    script: |
-      go build -C custom-targets/util/applysetters
-      go build -C custom-targets/util/clouddeploy
-      go build -C custom-targets/git-ops/git-deployer
-      go build -C custom-targets/helm/helm-deployer
-      go build -C custom-targets/terraform/terraform-deployer
-      go build -C custom-targets/infrastructure-manager/im-deployer
-      go build -C custom-targets/vertex-ai/model-deployer
-      go build -C postdeploy-hooks/k8s-cleanup
-      go build -C colors-e2e/colors-be
-      go build -C colors-e2e/colors-fd
   - name: docker
     script: |
-        docker build custom-targets/git-ops/git-deployer
-        docker build custom-targets/helm/helm-deployer
-        docker build custom-targets/terraform/terraform-deployer
-        docker build custom-targets/infrastructure-manager/im-deployer
-        docker build custom-targets/vertex-ai/model-deployer
-        docker build postdeploy-hooks/k8s-cleanup
+      set -e
+      # Find all directories that container a file named `Dockerfile`
+      for dir in $(find . -type d -exec test -e '{}'/Dockerfile \; -print); do
+        echo "BUILDING $dir"
+        docker build $dir
+      done


### PR DESCRIPTION
Automatically find directories containing Dockerfiles and build those.

Skip the redundant go builds: we already build the source as part of building the Dockerfiles.