### PR TITLE
Add helm namespace parameter to helm deployer

### DIFF
--- a/custom-targets/helm/README.md
+++ b/custom-targets/helm/README.md
@@ -18,6 +18,7 @@ The configuration provided when creating a Cloud Deploy Release must contain a [
 | --- | --- | --- |
 | customTarget/helmGKECluster| Yes | Name of the GKE cluster the Helm chart is deployed to, e.g. `projects/{project}/locations/{location}/clusters/{cluster}` |
 | customTarget/helmConfigurationPath | No | Path to the Helm chart in the Cloud Deploy release archive. If not provided then defaults to `mychart` in the root directory of the archive |
+| customTarget/helmNamespace| No | The namespace for the helm requests. Uses default namespace when not provided |
 | customTarget/helmTemplateLookup | No | Whether to handle lookup functions when performing `helm template` for the informational release manifest, requires connecting to the cluster at render time |
 | customTarget/helmTemplateValidate | No | Whether to validate the manifest produced by `helm template` against the cluster, requires connecting to the cluster at render time |
 | customTarget/helmUpgradeTimeout | No | Timeout duration when performing `helm upgrade`, if unset relies on Helm default |
@@ -53,6 +54,8 @@ The render process consists of the following steps:
 
     b. If `customTarget/helmTemplateValidate` is `true` then `--validate` arg is used.
 
+    c. If `customTarget/helmNamespace` is defined then `--namespace=${customTarget/helmNamespace}` arg is used.
+
 4. Upload to Cloud Storage the manifest produced by `helm template` to be used as the [Cloud Deploy Release inspector](https://cloud.google.com/deploy/docs/view-release#view_release_artifacts) artifact.
 
 5. Upload the configuration to Cloud Storage so the Helm chart is available at deploy time.
@@ -67,5 +70,9 @@ The deploy process consists of the following steps:
 3. Run `helm upgrade` for the provided Helm chart using the Cloud Deploy Delivery Pipeline ID as the Helm Release name.
 
     a. If `customTarget/helmUpgradeTimeout` is set, e.g. `10m`, then `--timeout=10m` arg is used.
+    
+    b. If `customTarget/helmNamespace` is defined then `--namespace=${customTarget/helmNamespace}` arg is used.
 
 4. Run `helm get manifest` to get the manifest applied by the Helm Release and upload it to Cloud Storage as a Cloud Deploy deploy artifact.
+
+    a. If `customTarget/helmNamespace` is defined then `--namespace=${customTarget/helmNamespace}` arg is used.

--- a/custom-targets/helm/helm-deployer/deploy.go
+++ b/custom-targets/helm/helm-deployer/deploy.go
@@ -95,12 +95,13 @@ func (d *deployer) deploy(ctx context.Context) (*clouddeploy.DeployResult, error
 	// Use the pipeline ID as the helm release since this should be consistent.
 	helmRelease := d.req.Pipeline
 	chartPath := determineChartPath(d.params)
-	if _, err := helmUpgrade(helmRelease, chartPath, &helmUpgradeOptions{timeout: d.params.upgradeTimeout}); err != nil {
+	hOpts := helmOptions{namespace: d.params.namespace}
+	if _, err := helmUpgrade(helmRelease, chartPath, &helmUpgradeOptions{helmOptions: hOpts, timeout: d.params.upgradeTimeout}); err != nil {
 		return nil, fmt.Errorf("error running helm upgrade: %v", err)
 	}
 
 	// After `helm upgrade` succeeds get the manifest to upload as the deploy artifact.
-	manifest, err := helmGetManifest(helmRelease)
+	manifest, err := helmGetManifest(helmRelease, &helmOptions{namespace: d.params.namespace})
 	if err != nil {
 		return nil, fmt.Errorf("error running helm get manifest aft upgrade: %v", err)
 	}

--- a/custom-targets/helm/helm-deployer/params.go
+++ b/custom-targets/helm/helm-deployer/params.go
@@ -26,6 +26,7 @@ import (
 const (
 	gkeClusterEnvkey       = "CLOUD_DEPLOY_customTarget_helmGKECluster"
 	configPathEnvKey       = "CLOUD_DEPLOY_customTarget_helmConfigurationPath"
+	namespaceEnvKey        = "CLOUD_DEPLOY_customTarget_helmNamespace"
 	templateLookupEnvKey   = "CLOUD_DEPLOY_customTarget_helmTemplateLookup"
 	templateValidateEnvKey = "CLOUD_DEPLOY_customTarget_helmTemplateValidate"
 	upgradeTimeoutEnvKey   = "CLOUD_DEPLOY_customTarget_helmUpgradeTimeout"
@@ -38,6 +39,8 @@ type params struct {
 	// Path to the helm chart in the Cloud Deploy release archive. If not provided then
 	// defaults to "mychart" in the root directory of the archive.
 	configPath string
+	// Namespace scope of the request.
+	namespace string
 	// Whether to handle lookup functions when performing helm template for the informational
 	// release manifest, requires connecting to the cluster at render time.
 	templateLookup bool
@@ -78,6 +81,7 @@ func determineParams() (*params, error) {
 	return &params{
 		gkeCluster:       cluster,
 		configPath:       os.Getenv(configPathEnvKey),
+		namespace:        os.Getenv(namespaceEnvKey),
 		templateLookup:   templateLookup,
 		templateValidate: templateValidate,
 		upgradeTimeout:   os.Getenv(upgradeTimeoutEnvKey),

--- a/custom-targets/helm/helm-deployer/render.go
+++ b/custom-targets/helm/helm-deployer/render.go
@@ -104,7 +104,8 @@ func (r *renderer) render(ctx context.Context) (*clouddeploy.RenderResult, error
 	// Use the pipeline ID as the helm release since this should be consistent.
 	helmRelease := r.req.Pipeline
 	chartPath := determineChartPath(r.params)
-	templateOut, err := helmTemplate(helmRelease, chartPath, &helmTemplateOptions{lookup: r.params.templateLookup, validate: r.params.templateValidate})
+	hOpts := helmOptions{namespace: r.params.namespace}
+	templateOut, err := helmTemplate(helmRelease, chartPath, &helmTemplateOptions{helmOptions: hOpts, lookup: r.params.templateLookup, validate: r.params.templateValidate})
 	if err != nil {
 		return nil, fmt.Errorf("error running helm template: %v", err)
 	}


### PR DESCRIPTION
Most helm charts need to be deployed to a specific namespace in a production Kubernetes cluster.

* Added new namespace parameter
* Fixed typo
* Updated README for new parameter