### PR TITLE
Remove TestDeployPipeline test

### DIFF
--- a/custom-targets/vertex-ai-pipeline/pipeline-deployer/vertexai_test.go
+++ b/custom-targets/vertex-ai-pipeline/pipeline-deployer/vertexai_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"context"
 	"testing"
-
-	"google.golang.org/api/aiplatform/v1"
 )
 
 // Tests that pipelineRequestFromManifest fails when given an incorrect path. Does not test correct path or incomplete file!
@@ -20,15 +17,6 @@ func TestPipelineRequestFromManifest(t *testing.T) {
 	}
 
 	_, err = pipelineRequestFromManifest(" ")
-	if err == nil {
-		t.Errorf("Expected: error, Actual: %s", err)
-	}
-}
-
-// Tests that deployPipeline fails as expected. Does not test actual deployment
-func TestDeployPipeline(t *testing.T) {
-	aiService, _ := newAIPlatformService(context.Background(), "us-central1")
-	err := deployPipeline(context.Background(), aiService, "projects/scortabarria-internship/locations/us-central1", &aiplatform.GoogleCloudAiplatformV1CreatePipelineJobRequest{})
 	if err == nil {
 		t.Errorf("Expected: error, Actual: %s", err)
 	}


### PR DESCRIPTION
Remove `TestDeployPipeline` test from vertex_ai_pipeline custom target. It doesn't work, causing a nil pointer dereference since the function calls  request.PipelineJob and in this test it's passing in a nil `CreatePipelineJobRequest`.