### PR TITLE
update polling function

### DIFF
--- a/custom-targets/vertex-ai/model-deployer/polling.go
+++ b/custom-targets/vertex-ai/model-deployer/polling.go
@@ -17,10 +17,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"google.golang.org/api/aiplatform/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sync"
 	"time"
+
+	"google.golang.org/api/aiplatform/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -42,8 +43,7 @@ func poll(ctx context.Context, service *aiplatform.Service, op *aiplatform.Googl
 	}
 
 	pollFunc := getWaitFunc(opService, op.Name, ctx)
-
-	err = wait.PollUntilContextTimeout(ctx, lroOperationTimeout, pollingTimeout, true, pollFunc)
+	err = wait.PollImmediateWithContext(ctx, lroOperationTimeout, pollingTimeout, pollFunc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Update the polling function used to one that exists in the internal mirror. I am aware it is deprecated, so once the mirror is updated this can be updated to use a new function from the [wait package](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#PollImmediateWithContext)